### PR TITLE
🔧 Fix Dockerfile path in version bump script

### DIFF
--- a/scripts/determine-version-bump.sh
+++ b/scripts/determine-version-bump.sh
@@ -100,7 +100,7 @@ extract_version_changes() {
 
 # Main execution
 main() {
-    local dockerfile="${1:-proton-drive-backup/Dockerfile}"
+    local dockerfile="${1:-Dockerfile}"
 
     if [[ ! -f "$dockerfile" ]]; then
         echo "Error: Dockerfile not found at $dockerfile" >&2


### PR DESCRIPTION
Fixes release workflow failure by updating script to look for Dockerfile at repository root.

**Error fixed**: 'Dockerfile not found at proton-drive-backup/Dockerfile'  
**Solution**: Updated path from 'proton-drive-backup/Dockerfile' to 'Dockerfile'

This will allow the release workflow to succeed and create the 'latest' tag.