### PR TITLE
🏷️ Add version tag creation to release workflow

### DIFF
--- a/.github/workflows/proton-backup-release.yml
+++ b/.github/workflows/proton-backup-release.yml
@@ -83,17 +83,13 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$SOURCE_TAG \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
-          # Add version tags from metadata
-          IFS=',' read -ra TAGS <<< "${{ steps.meta.outputs.tags }}"
-          for tag in "${TAGS[@]}"; do
-            tag=$(echo "$tag" | xargs) # trim whitespace
-            if [[ "$tag" != *":latest" ]]; then
-              echo "Adding tag: $tag"
-              docker buildx imagetools create \
-                ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$SOURCE_TAG \
-                --tag "$tag"
-            fi
-          done
+          # Add version tag if a release was created
+          if [ "${{ steps.tag.outputs.new_tag }}" != "" ]; then
+            echo "Adding version tag: ${{ steps.tag.outputs.new_tag }}"
+            docker buildx imagetools create \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$SOURCE_TAG \
+              --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.new_tag }}
+          fi
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8


### PR DESCRIPTION
## Problem
Release workflow creates 'latest' tag but missing version tags (e.g. v0.0.28).

## Solution  
Add manual version tag creation in release workflow:
- Check if version bump created a new tag
- If yes, retag source image with version number
- Simplified from complex metadata tag processing

## Result
Container registry will show both tags:
- ✅ latest (always)  
- ✅ v0.0.28 (when version bumped)

Both tags point to the same source image that was built and scanned in the PR.